### PR TITLE
Don't send double-click event to click service

### DIFF
--- a/src/lib/src/core/viewer-service/viewer.service.ts
+++ b/src/lib/src/core/viewer-service/viewer.service.ts
@@ -78,7 +78,9 @@ export class ViewerService implements OnInit {
     });
 
     this.viewer.addHandler('canvas-click', this.clickService.click);
-    this.viewer.addHandler('canvas-double-click', this.clickService.click);
+    this.viewer.addHandler('canvas-double-click', (event: any) => {
+        event.preventDefaultAction = true;
+    });
   }
 
   public getZoom(): number {


### PR DESCRIPTION
Dobbel klikk skal fungere med denne endringen og med patchet openseadragon.
For å installere patchet versjon av open seadragon kjør yarn add git://github.com/ooystein/openseadragon.git#dblClick ( Med denne kommandoen skal man ikke få feilmeldingen "Permission denied (publickey)."